### PR TITLE
feat: ability to ignore images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format:
 
 .PHONY: run-tests # Runs all tests
 run-tests:
-	@go test
+	@go test ./...
 
 .PHONY: fetch-deps # Fetch all project dependencies
 fetch-deps:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 * Pull all images used by deployments in the cluster on all nodes
 * Watch for new, changed or removed deployments and pre-fetch images on all nodes
+* Ignore deployments with annotation `kube-image-prefetch/ignore: "true"`
+* Ignore specific containers with annotation `kube-image-prefetch/ignore-containers: "container-name"`. Multiple containers within a pod can be specified as a comma separated list.
 
 ## Install
 

--- a/internal/controller/images.go
+++ b/internal/controller/images.go
@@ -1,0 +1,36 @@
+package controller
+
+import (
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func getImages(dp appsv1.Deployment) []string {
+	images := []string{}
+
+	ignoreDP := dp.ObjectMeta.Annotations["kube-image-prefetch/ignore"]
+	if ignoreDP == "true" {
+		return images
+	}
+
+	ignoreContainersStr := dp.ObjectMeta.Annotations["kube-image-prefetch/ignore-containers"]
+	ignoreContainers := strings.Split(ignoreContainersStr, ",")
+
+	for _, container := range append(dp.Spec.Template.Spec.InitContainers, dp.Spec.Template.Spec.Containers...) {
+		if !contains(ignoreContainers, container.Name) {
+			images = append(images, container.Image)
+		}
+	}
+
+	return images
+}
+
+func contains(arr []string, str string) bool {
+	for _, c := range arr {
+		if strings.TrimSpace(strings.ToLower(str)) == strings.TrimSpace(strings.ToLower(c)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/images_test.go
+++ b/internal/controller/images_test.go
@@ -1,0 +1,245 @@
+package controller
+
+import (
+	"testing"
+	"reflect"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetImages_SingleImage(t *testing.T) {
+	dp := appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "container-1",
+							Image: "image:1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []string{"image:1"}
+	actual := getImages(dp)
+
+	if ! reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected images returned - %v", actual)
+	}
+}
+
+func TestGetImages_MultipleImage(t *testing.T) {
+	dp := appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "container-1",
+							Image: "image:1",
+						},
+						corev1.Container{
+							Name: "container-2",
+							Image: "image:2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []string{"image:1","image:2"}
+	actual := getImages(dp)
+
+	if ! reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected images returned - %v", actual)
+	}
+}
+
+func TestGetImages_InitContainers(t *testing.T) {
+	dp := appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						corev1.Container{
+							Name: "initcontainer-1",
+							Image: "initimage:1",
+						},
+					},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "container-1",
+							Image: "image:1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []string{"initimage:1","image:1"}
+	actual := getImages(dp)
+
+	if ! reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected images returned - %v", actual)
+	}
+}
+
+func TestGetImages_IgnoreDeployment(t *testing.T) {
+	dp := appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+			Annotations: map[string]string{
+				"kube-image-prefetch/ignore": "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						corev1.Container{
+							Name: "initcontainer-1",
+							Image: "initimage:1",
+						},
+					},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "container-1",
+							Image: "image:1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []string{}
+	actual := getImages(dp)
+
+	if ! reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected images returned - %v", actual)
+	}
+}
+
+func TestGetImages_IgnoreContainer(t *testing.T) {
+	dp := appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+			Annotations: map[string]string{
+				"kube-image-prefetch/ignore-containers": "initcontainer-1",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						corev1.Container{
+							Name: "initcontainer-1",
+							Image: "initimage:1",
+						},
+					},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "container-1",
+							Image: "image:1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []string{"image:1"}
+	actual := getImages(dp)
+
+	if ! reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected images returned - %v", actual)
+	}
+}
+
+func TestGetImages_IgnoreMultipleContainer(t *testing.T) {
+	dp := appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+			Annotations: map[string]string{
+				"kube-image-prefetch/ignore-containers": "initcontainer-1,container-1",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						corev1.Container{
+							Name: "initcontainer-1",
+							Image: "initimage:1",
+						},
+					},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "container-1",
+							Image: "image:1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []string{}
+	actual := getImages(dp)
+
+	if ! reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected images returned - %v", actual)
+	}
+}
+
+func TestGetImages_IgnoreContainerSpaces(t *testing.T) {
+	dp := appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+			Annotations: map[string]string{
+				"kube-image-prefetch/ignore-containers": "initcontainer-1, container-1",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						corev1.Container{
+							Name: "initcontainer-1",
+							Image: "initimage:1",
+						},
+					},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "container-1",
+							Image: "image:1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := []string{}
+	actual := getImages(dp)
+
+	if ! reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected images returned - %v", actual)
+	}
+}


### PR DESCRIPTION
Fixes #4 

* Ignore deployments with annotation `kube-image-prefetch/ignore: "true"`
* Ignore specific containers with annotation `kube-image-prefetch/ignore-containers: "container-name"`. Multiple containers within a pod can be specified as a comma separated list.

See images_test.go for examples.